### PR TITLE
adjust total expected episodes

### DIFF
--- a/venv/constant.py
+++ b/venv/constant.py
@@ -1,14 +1,14 @@
 from os import getcwd
 
 # command line default values
-EPISODES = 50000
+EPISODES = 5
 DELAY = 0
+SAVE_EPISODE = 1
 
 # external files
-DELETE_JSON = True
-SAVE_EPISODE = 10000
-RESUME_FILE = False
-RESUME_EPISODE = 10
+DELETE_JSON = False
+RESUME = True
+RESUME_EPISODE = 50000
 JSON_DIR = str(getcwd()) + '/json/'
 DATA_DIR = str(getcwd()) + '/measurements/'
 
@@ -17,7 +17,7 @@ TILE = 44
 WIDTH = 8
 HEIGHT = 8
 SNAKE_LENGTH = 1
-SNAKE_X, SNAKE_Y = 2 * 44, 2 * 44
+SNAKE_X, SNAKE_Y = 1 * 44, 1 * 44
 
 # directions
 EAST = (1, 0)

--- a/venv/game.py
+++ b/venv/game.py
@@ -155,23 +155,24 @@ class Game:
         else:        # south
             self.snake.set_south()
 
-    def ai_train(self, delay: int, total_episodes: int, saved_table: bool):
+    def ai_train(self, delay: int, total_episodes: int, resume_state: bool):
         """
         Executes the AI training, looping until the snake is trained the total number of episodes.
         Movements are implemented by the AI rather than by a human pressing keys.
         :param delay: defines the frame delay with lower values (e.g. 1) resulting in a fast frame, while higher values
         (e.g. 1000) result in very slow frames
         :param total_episodes: total number of episodes to run the game
-        :param saved_table: if True, start training from externally saved table's next episode, if False,
+        :param resume_state: if True, start training from externally saved table's next episode, if False,
         initial episode is 1
         """
 
-        # If resuming from a saved table state, load the state and start from the loaded
-        # state's NEXT episode
-        if saved_table:
+        # If resuming from a saved state, start from the loaded state's next episode
+        if resume_state:
             filename = 'episode' + str(constant.RESUME_EPISODE) + '.json'
             self.episode = self.q.load_table(filename)
-            exit(0)  # TODO delete
+            total_episodes += self.episode
+            if self.episode < 1:
+                print(f'Table failed to load')  # TODO turn this into an exception
 
         while self._running:
             pygame.event.pump()
@@ -297,7 +298,7 @@ if __name__ == "__main__":
 
     # select game play
     if ai == 'y':
-        game.ai_train(delayed, total_episode_number, constant.RESUME_FILE)
+        game.ai_train(delayed, total_episode_number, constant.RESUME)
         print(f'\nTEST RUN:')
         game.ai_test(delayed)
     else:

--- a/venv/q_learning.py
+++ b/venv/q_learning.py
@@ -123,7 +123,6 @@ class QLearning:
         if os.path.exists(path):
             with open(path) as f:
                 self.table = load(f)
-                print(f'LOADED table: \n{self.table}')
                 f.close()
                 return constant.RESUME_EPISODE + 1
         return -1


### PR DESCRIPTION
The total episodes (passed from main) were lower than the resumed episodes value and resulted in an immediate exit. This is fixed now.